### PR TITLE
Updating citation URL and hosting R Book PDF on github

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Authors@R: c(
     person("Paul", "Morrill", role = "ctb"),
     person("Josh", "Sayers", role = "ctb"),
     person("Philip", "Taylor", role = "ctb"))
-URL: https://github.com/motusWTS/motus, https://motusWTS.github.io/motus, https://motus.org
+URL: https://motusWTS.github.io/motus/
 Depends:
     R (>= 3.2.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Authors@R: c(
     person("Paul", "Morrill", role = "ctb"),
     person("Josh", "Sayers", role = "ctb"),
     person("Philip", "Taylor", role = "ctb"))
-URL: https://motusWTS.github.io/motus/
+URL: https://motuswts.github.io/motus/
 Depends:
     R (>= 3.2.0)
 Imports:

--- a/_pkgdown_en.yml
+++ b/_pkgdown_en.yml
@@ -92,7 +92,7 @@ articles:
   navbar: ~
   desc: "This is a complete walk-through, originally compiled as the Motus R book.
         These articles are largely based on the original Motus R Book by 
-        [Crewe et al. 2018](https://motus.org/motusRBook/archives/MotusRBook2018-01.pdf), 
+        [Crewe et al. 2018](https://raw.githubusercontent.com/MotusWTS/motus/master/inst/extdata/MotusRBook2018-01.pdf), 
         and have since been supplemented by [various people on the Motus team](01-introduction.html#acknowledgements)."
   contents:
   - articles/01-introduction

--- a/_pkgdown_fr.yml
+++ b/_pkgdown_fr.yml
@@ -91,7 +91,7 @@ articles:
 - title: Visite complète
   desc: "This is a complete walk-through, originally compiled as the Motus R book.
         These articles are largely based on the original Motus R Book by 
-        [Crewe et al. 2018](https://motus.org/motusRBook/archives/MotusRBook2018-01.pdf), 
+        [Crewe et al. 2018](https://raw.githubusercontent.com/MotusWTS/motus/master/inst/extdata/MotusRBook2018-01.pdf), 
         and have since been supplemented by [various people on the Motus team](01-introduction.html#acknowledgements)."
   contents:
   - articles/01-introduction

--- a/vignettes/articles/01-introduction.Rmd
+++ b/vignettes/articles/01-introduction.Rmd
@@ -77,7 +77,7 @@ Department of Biology, Western University, Canada
 
 ## Acknowledgements
 
-These articles are largely based on the original Motus R Book by [Crewe et al. 2018](https://motus.org/motusRBook/archives/MotusRBook2018-01.pdf), and have been supplemented by numerous Motus collaborators and Birds Canada Motus staff.
+These articles are largely based on the original Motus R Book by [Crewe et al. 2018](https://raw.githubusercontent.com/MotusWTS/motus/master/inst/extdata/MotusRBook2018-01.pdf), and have been supplemented by numerous Motus collaborators and Birds Canada Motus staff.
 
 Motus is an international collaborative research network that uses coordinated automated radio telemetry to facilitate research and education on the ecology and conservation of small organisms. Motus is a program of Birds Canada in partnership with collaborating researchers and organizations. The Motus website includes a list of [Motus partners and collaborators](https://motus.org/data/partners). If your organization is not listed, please contact <motus@birdscanada.org>.
 


### PR DESCRIPTION
Just a small update to change the URL listed in the package citation to be motuswts.github.io/motus instead of listing 3 URLs (github.com/MotusWTS/motus, motuswts.github.io, motus.org) because the hyperlink was treating them as one URL and leading to an error page. Since it's the citation for the motus R package, I think only the link to the R package website is needed.

I also uploaded the archived R Book PDF to github. Denis is implementing a redirect on the motus website so that all URLs referring to the R Book will lead to the new R package website. It is simpler if he doesn't need to make an exception for the PDF R Book, but possible if hosting on github isn't a good idea. I just added it to the main motus github directory (https://github.com/MotusWTS/motus), but maybe it would be better to host it on the new R package website? I just wasn't sure where to save the file to have it hosted there. Is that possible?